### PR TITLE
rabbit_stream_reader: Handle {error, _} from send_chunks at all call sites

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2113,6 +2113,14 @@ handle_frame_post_auth(Transport,
                                                "peer",
                                                []),
                     throw({stop, normal});
+                {error, Reason} ->
+                    ?LOG_INFO("Error while sending chunks: ~tp",
+                                               [Reason]),
+                    {Connection,
+                     State#stream_connection_state{consumers =
+                                                       Consumers#{SubscriptionId
+                                                                      =>
+                                                                      Consumer}}};
                 {ok, Consumer1} ->
                     {Connection,
                      State#stream_connection_state{consumers =
@@ -2991,6 +2999,11 @@ maybe_dispatch_on_subscription(Transport,
                                        "peer",
                                        []),
             throw({stop, normal});
+        {error, Reason} ->
+            ?LOG_INFO("Error while sending chunks: ~tp",
+                                       [Reason]),
+            Consumers1 = Consumers#{SubscriptionId => ConsumerState},
+            State#stream_connection_state{consumers = Consumers1};
         {ok, #consumer{log = Log1, credit = Credit1} = ConsumerState1} ->
             Consumers1 = Consumers#{SubscriptionId => ConsumerState1},
 
@@ -3745,6 +3758,8 @@ send_file_callback(?VERSION_2,
        FrameBeginning
     end.
 
+-spec send_chunks(term(), module(), #consumer{}, atomics:atomics_ref()) ->
+    {ok, #consumer{}} | {error, term()}.
 send_chunks(DeliverVersion,
             Transport,
             #consumer{credit = Credit, last_listener_offset = LastLstOffset} =


### PR DESCRIPTION
## Summary

- Add `{error, Reason}` handling to two `send_chunks` call sites in `rabbit_stream_reader` that were missing it
- Add a `-spec` for `send_chunks/4` so dialyzer enforces exhaustive matching going forward

## Problem

`send_chunks` can return `{error, Reason}` when the `osiris_log_reader` behaviour's `send_file` callback returns an error. The `osiris_log_reader` behaviour explicitly declares `{error, term()}` as a valid return from both `send_file` and `chunk_iterator` callbacks.

Two of four `send_chunks` call sites in `rabbit_stream_reader` do not match this return value:

- `handle_frame_post_auth/4` (credit handling path)
- `maybe_dispatch_on_subscription/10` (initial subscription dispatch)

This causes `{case_clause, {error, timeout}}` crashes that propagate to `rabbit_stream_connection_sup`, hitting `reached_max_restart_intensity` and killing the entire stream connection (all consumers and producers).

The other two call sites (osiris offset event at line 1159 and SAC consumer update at line 2603) already handle `{error, Reason}` correctly by logging and returning the consumer unchanged.

## Evidence

Observed during a 2-hour soak test with the `rabbitmq_stream_s3` tiered storage plugin under sustained S3 latency:

```
exception error: no case clause matching {error,timeout}
  in function  rabbit_stream_reader:maybe_dispatch_on_subscription/10
  in function  rabbit_stream_reader:handle_frame_post_auth/4
```

6,890 crashes on a single node, all with the same pattern.

## Test plan

- [x] Compiles cleanly
- [x] Dialyzer passes
- [ ] Deploy to test cluster and verify no `case_clause` crashes under S3 latency
