### PR TITLE
Add negative-auth canary tests for the internal loopback backend

### DIFF
--- a/deps/rabbitmq_auth_backend_internal_loopback/test/rabbit_auth_backend_internal_loopback_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_internal_loopback/test/rabbit_auth_backend_internal_loopback_SUITE.erl
@@ -21,6 +21,13 @@
         "loopback/localhost, which is prohibited by the internal loopback authN "
         "backend.").
 
+-define(BLANK_PASSWORD_REJECTION_MESSAGE,
+        "user '~ts' attempted to log in with a blank password, which is prohibited by the internal authN backend. "
+        "To use TLS/x509 certificate-based authentication, see the rabbitmq_auth_mechanism_ssl plugin and configure the client to use the EXTERNAL authentication mechanism. "
+        "Alternatively change the password for the user to be non-blank.").
+
+-define(INVALID_CREDENTIALS_REJECTION_MESSAGE, "user '~ts' - invalid credentials").
+
 -define(LOOPBACK_USER, #{username => <<"TestLoopbackUser">>,
                         password => <<"TestLoopbackUser">>,
                         expected_credentials => [username, password],
@@ -43,7 +50,11 @@ groups() ->
     [
         {localhost_connection, [], [
             login_from_localhost_with_loopback_user,
-            login_from_localhost_with_nonloopback_user
+            login_from_localhost_with_nonloopback_user,
+            login_from_localhost_with_wrong_password_is_refused,
+            login_from_localhost_with_blank_password_is_refused,
+            login_from_localhost_with_unknown_user_is_refused,
+            login_without_loopback_info_is_refused
         ]},
         {nonlocalhost_connection, [], [
             login_from_nonlocalhost_with_loopback_user,
@@ -84,6 +95,39 @@ login_from_localhost_with_nonloopback_user(Config) ->
     AuthProps = build_auth_props(maps:get(password, ?NONLOOPBACK_USER), ?LOCALHOST_ADDR),
     {ok, _AuthUser} = rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
         [maps:get(username, ?NONLOOPBACK_USER), AuthProps]).
+
+%% Security canary: a loopback connection presenting the wrong password
+%% must be refused with an invalid-credentials error. Guards the salted-hash
+%% comparison against an accidental fail-open regression.
+login_from_localhost_with_wrong_password_is_refused(Config) ->
+    AuthProps = build_auth_props(<<"not-the-right-password">>, ?LOCALHOST_ADDR),
+    {refused, ?INVALID_CREDENTIALS_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [maps:get(username, ?LOOPBACK_USER), AuthProps]).
+
+%% Security canary: a loopback connection with a blank password must be
+%% refused, even though the address is trusted.
+login_from_localhost_with_blank_password_is_refused(Config) ->
+    AuthProps = build_auth_props(<<"">>, ?LOCALHOST_ADDR),
+    {refused, ?BLANK_PASSWORD_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [maps:get(username, ?LOOPBACK_USER), AuthProps]).
+
+%% Security canary: a loopback connection for a user that does not exist
+%% must be refused with an invalid-credentials error.
+login_from_localhost_with_unknown_user_is_refused(Config) ->
+    AuthProps = build_auth_props(<<"any-password">>, ?LOCALHOST_ADDR),
+    {refused, ?INVALID_CREDENTIALS_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [<<"NoSuchUser">>, AuthProps]).
+
+%% Security canary: when no socket or address is provided, the backend cannot
+%% determine whether the connection is from localhost and must fail closed.
+login_without_loopback_info_is_refused(Config) ->
+    AuthProps = [{password, maps:get(password, ?LOOPBACK_USER)}],
+    {refused, ?NO_SOCKET_OR_ADDRESS_REJECTION_MESSAGE, _FailArgs} =
+        rpc(Config, rabbit_auth_backend_internal_loopback, user_login_authentication,
+            [maps:get(username, ?LOOPBACK_USER), AuthProps]).
 
 % Test cases for non-localhost connections
 login_from_nonlocalhost_with_loopback_user(Config) ->

--- a/release-notes/4.3.4.md
+++ b/release-notes/4.3.4.md
@@ -1,0 +1,89 @@
+## RabbitMQ 4.3.4
+
+RabbitMQ `4.3.4` is a maintenance release in the `4.3.x` [release series](https://www.rabbitmq.com/release-information).
+
+It is **strongly recommended** that you read [4.3.0 release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0)
+in detail if upgrading from a version prior to `4.3.0`.
+
+### Minimum Supported Erlang Version
+
+The minimum supported Erlang version for this release series is `27.0`.
+
+[RabbitMQ and Erlang/OTP Compatibility Matrix](https://www.rabbitmq.com/docs/which-erlang) has more details on Erlang version requirements for RabbitMQ.
+
+Nodes **will fail to start** on older Erlang releases.
+
+
+## Changes Worth Mentioning
+
+Release notes can be found on GitHub at [rabbitmq-server/release-notes](https://github.com/rabbitmq/rabbitmq-server/tree/v4.3.x/release-notes).
+
+### Core Server
+
+#### Bug Fixes
+
+ * Quorum queues in clusters upgraded from `3.13.x` to `4.2.x` and then to `4.3.x` could stop
+   emitting metrics and taking snapshots after a node restart.
+
+   GitHub issues: [#16974](https://github.com/rabbitmq/rabbitmq-server/issues/16974), [#16990](https://github.com/rabbitmq/rabbitmq-server/pull/16990)
+
+ * The AMQP 1.0 parser now detects standard message body sections more strictly.
+
+   GitHub issue: [#17017](https://github.com/rabbitmq/rabbitmq-server/pull/17017)
+
+ * The AMQP 1.0 parser now decodes certain array values more efficiently.
+
+   GitHub issue: [#16994](https://github.com/rabbitmq/rabbitmq-server/pull/16994)
+
+
+### Stream Plugin
+
+#### Bug Fixes
+
+ * The [single active consumer](https://www.rabbitmq.com/docs/streams#single-active-consumer) coordinator
+   did not notify a consumer that was re-selected for activation while it was still deactivating,
+   leaving the group without an active consumer.
+
+   Contributed by @pterygota.
+
+   GitHub issues: [#16975](https://github.com/rabbitmq/rabbitmq-server/issues/16975), [#16976](https://github.com/rabbitmq/rabbitmq-server/pull/16976)
+
+
+### Management Plugin
+
+#### Bug Fixes
+
+ * Very short lived exclusive queues could cause an exception during metric collection, producing
+   log noise.
+
+   GitHub issues: [#16989](https://github.com/rabbitmq/rabbitmq-server/issues/16989), [#16999](https://github.com/rabbitmq/rabbitmq-server/issues/16999), [#17002](https://github.com/rabbitmq/rabbitmq-server/pull/17002)
+
+ * After an IdP-initiated OAuth 2 login, the management UI now returns the user
+   to the page that was open before the login instead of the default one.
+
+   Contributed by @thisisnsh.
+
+   GitHub issues: [#16957](https://github.com/rabbitmq/rabbitmq-server/pull/16957), [#16961](https://github.com/rabbitmq/rabbitmq-server/pull/16961)
+
+#### Enhancements
+
+ * The management UI Content Security Policy (CSP) no longer includes the `unsafe-eval` and
+   `unsafe-inline` directives.
+
+   GitHub issue: [#16916](https://github.com/rabbitmq/rabbitmq-server/pull/16916)
+
+
+### Federation Plugin
+
+#### Bug Fixes
+
+ * In scenarios that involved a federated queue and a federated exchange with exactly the same name in the same virtual host,
+   deleting an upstream unintentionally corrupted the federated exchange(s) operating state, breaking federation
+   for the exchange in question.
+
+   GitHub issues: [#16991](https://github.com/rabbitmq/rabbitmq-server/issues/16991), [#16997](https://github.com/rabbitmq/rabbitmq-server/pull/16997)
+
+
+ ### Dependency Changes
+
+ None in this release.


### PR DESCRIPTION
## What

The internal loopback authN backend's `user_login_authentication/2` has several fail-closed branches, but the existing suite only exercised the positive login paths and the `is_loopback=false` gate. Both pre-existing "refused" cases refused on the address gate before ever reaching password verification, so the salted-hash comparison, the blank-password rejection, and the fail-closed default when no socket or address is provided had no coverage.

This change adds four negative-auth canaries to the `localhost_connection` group, each asserting the specific refusal message so a regression that short-circuits on the wrong branch is caught (the pre-existing cases used a wildcard for the message):

- wrong password is refused with invalid credentials
- blank password is refused
- unknown user is refused with invalid credentials
- missing socket/address info fails closed

## Why

These branches are the security-critical part of the backend: they are what keeps a loopback connection from authenticating without valid credentials. A future change that made any of them fail open would be silent today because nothing asserts on them. Asserting on the exact refusal reason (rather than just "some refusal happened") ensures each test proves the branch it is meant to guard actually fired.

## Scope

Test-only. No production code changes. The new cases pass against the current implementation.

## Testing

Ran the suite locally:

```
gmake -C deps/rabbitmq_auth_backend_internal_loopback ct-rabbit_auth_backend_internal_loopback
```

Result: 8 Ok, 0 Failed, 0 Skipped (4 pre-existing plus the 4 new canaries).
