### PR TITLE
Expose quorum-queue WAL and segment writer metrics via Prometheus

### DIFF
--- a/deps/rabbitmq_prometheus/metrics.md
+++ b/deps/rabbitmq_prometheus/metrics.md
@@ -259,6 +259,8 @@ These metrics are specific to the stream protocol.
 | rabbitmq_raft_mem_tables                 | Number of in-memory tables handled                                                  |
 | rabbitmq_raft_entries                    | Number of entries written                                                           |
 | rabbitmq_raft_bytes_written              | Number of bytes written                                                             |
+| rabbitmq_raft_batches                    | Number of write-ahead log batches flushed. Each batch is one fsync                  |
+| rabbitmq_raft_writes                     | Number of write-ahead log writes. Many writes are batched into a single fsync        |
 
 ### Federation
 

--- a/deps/rabbitmq_prometheus/metrics.md
+++ b/deps/rabbitmq_prometheus/metrics.md
@@ -261,6 +261,8 @@ These metrics are specific to the stream protocol.
 | rabbitmq_raft_bytes_written              | Number of bytes written                                                             |
 | rabbitmq_raft_batches                    | Number of write-ahead log batches flushed. Each batch is one fsync                  |
 | rabbitmq_raft_writes                     | Number of write-ahead log writes. Many writes are batched into a single fsync        |
+| rabbitmq_raft_current_file_size          | Current size in bytes of the write-ahead log file being written                      |
+| rabbitmq_raft_max_file_size              | Size in bytes at which the write-ahead log file is rolled                            |
 
 ### Federation
 

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
@@ -156,7 +156,11 @@ collect_key_component_metrics(Prefix, Callback) ->
     %% coordination (Khepri) and quorum_queues rows are exposed. Without the
     %% quorum_queues rows there is no way to observe quorum-queue WAL write,
     %% batch (fsync) or bytes-written activity from the Prometheus endpoint.
-    WALMetrics = [batches, writes, bytes_written, wal_files, mem_tables],
+    %% current_file_size and max_file_size make the WAL's fill state visible.
+    %% wal_files only increments after a roll, so on its own it reports the
+    %% fsync spike after the fact rather than the approach to it.
+    WALMetrics = [batches, writes, bytes_written, wal_files, mem_tables,
+                  current_file_size, max_file_size],
     SegmentWriterMetrics = [entries, segments],
     QQComponentResult =
         seshat:format(ra,

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_raft_metrics_collector.erl
@@ -149,9 +149,26 @@ collect_max_values(Prefix, Callback) ->
                       filter_fun => fun does_belong_to_quorum_queue/1})).
 
 collect_key_component_metrics(Prefix, Callback) ->
-    %% quorum queue metrics
-    WALMetrics = [wal_files, bytes_written, mem_tables],
+    %% The write-ahead log and segment writer are per-node processes shared by
+    %% all Raft servers of a given Ra system. Their counters are labelled by
+    %% ra_system (and module) but carry no `queue` label, so the per-queue
+    %% filter does not match them. Select them by ra_system so that both the
+    %% coordination (Khepri) and quorum_queues rows are exposed. Without the
+    %% quorum_queues rows there is no way to observe quorum-queue WAL write,
+    %% batch (fsync) or bytes-written activity from the Prometheus endpoint.
+    WALMetrics = [batches, writes, bytes_written, wal_files, mem_tables],
     SegmentWriterMetrics = [entries, segments],
+    QQComponentResult =
+        seshat:format(ra,
+                      #{labels => as_binary,
+                        metrics => WALMetrics ++ SegmentWriterMetrics,
+                        filter_fun => fun does_belong_to_quorum_queue_system/1}),
+    %% Khepri and other coordination metrics, including the coordination system's
+    %% own WAL and segment writer counters.
+    CoordinationResult =
+        seshat:format(ra,
+                      #{labels => as_binary,
+                        filter_fun => fun does_belong_to_coordination_system/1}),
     maps:foreach(
       fun(Name, #{type := Type, help := Help, values := Values}) ->
               Callback(
@@ -160,22 +177,7 @@ collect_key_component_metrics(Prefix, Callback) ->
                           Type,
                           Values))
       end,
-      seshat:format(ra,
-                    #{labels => as_binary,
-                      metrics => WALMetrics ++ SegmentWriterMetrics,
-                      filter_fun => fun does_belong_to_quorum_queue/1})),
-    %% Khepri and other coordination metrics
-    maps:foreach(
-      fun(Name, #{type := Type, help := Help, values := Values}) ->
-              Callback(
-                create_mf(<<Prefix/binary, (prometheus_model_helpers:metric_name(Name))/binary>>,
-                          Help,
-                          Type,
-                          Values))
-      end,
-      seshat:format(ra,
-                    #{labels => as_binary,
-                      filter_fun => fun does_belong_to_coordination_system/1})).
+      merge_format_results(CoordinationResult, QQComponentResult)).
 
 %% Merges two `seshat:format/2` results, combining
 %% values under a single metric family entry.
@@ -195,3 +197,6 @@ does_belong_to_coordination_system(_) -> false.
 
 does_belong_to_quorum_queue(#{queue := _}) -> true;
 does_belong_to_quorum_queue(_) -> false.
+
+does_belong_to_quorum_queue_system(#{ra_system := quorum_queues}) -> true;
+does_belong_to_quorum_queue_system(_) -> false.

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -453,7 +453,11 @@ aggregated_metrics_test(Config) ->
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_bytes_written.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_writes.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_batches.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
-    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])).
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    %% The WAL size gauges make the fill state observable. wal_files above only
+    %% increments after a roll, so it reports the fsync spike after the fact.
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_current_file_size.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_max_file_size.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])).
 
 %% Verify that the aggregated endpoint does not emit duplicate TYPE
 %% lines for Raft metrics that belong to different Ra systems.
@@ -471,7 +475,9 @@ aggregated_endpoint_no_duplicate_raft_type_lines(Config) ->
                                     "rabbitmq_raft_entries",
                                     "rabbitmq_raft_mem_tables",
                                     "rabbitmq_raft_segments",
-                                    "rabbitmq_raft_wal_files"]).
+                                    "rabbitmq_raft_wal_files",
+                                    "rabbitmq_raft_current_file_size",
+                                    "rabbitmq_raft_max_file_size"]).
 
 endpoint_per_object_metrics(Config) ->
     per_object_metrics_test(Config, "/metrics/per-object").

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -445,7 +445,15 @@ aggregated_metrics_test(Config) ->
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_entries{", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_mem_tables{", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_segments{", [{capture, none}, multiline])),
-    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files{", [{capture, none}, multiline])).
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files{", [{capture, none}, multiline])),
+    %% The write-ahead log and segment writer counters must be exposed for the
+    %% quorum_queues Ra system, not only for coordination (Khepri). Without
+    %% these rows there is no way to observe quorum-queue WAL write, batch
+    %% (fsync) or bytes-written activity from the Prometheus endpoint.
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_bytes_written.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_writes.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_batches.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_raft_wal_files.*ra_system=\"quorum_queues\"", [{capture, none}, multiline])).
 
 %% Verify that the aggregated endpoint does not emit duplicate TYPE
 %% lines for Raft metrics that belong to different Ra systems.
@@ -458,6 +466,8 @@ aggregated_endpoint_no_duplicate_raft_type_lines(Config) ->
                                     "rabbitmq_raft_max_commit_latency_seconds",
                                     "rabbitmq_raft_max_num_segments",
                                     "rabbitmq_raft_bytes_written",
+                                    "rabbitmq_raft_batches",
+                                    "rabbitmq_raft_writes",
                                     "rabbitmq_raft_entries",
                                     "rabbitmq_raft_mem_tables",
                                     "rabbitmq_raft_segments",


### PR DESCRIPTION
## What

The `quorum_queues` Ra system's write-ahead log and segment-writer counters are never emitted on `/metrics`. Upstream selects them with `does_belong_to_quorum_queue/1`, which matches on a `queue` label that WAL counters do not carry, so only the coordination (Khepri) system's WAL appears. There is no way to observe quorum-queue WAL write, batch (fsync) or bytes-written activity from the Prometheus endpoint.

Two commits:

1. **Select the WAL and segment-writer counters by `ra_system`** and merge the coordination and `quorum_queues` results into a single metric family per name, so each metric carries one row per `ra_system` without duplicate HELP or TYPE lines.
2. **Add the WAL size gauges** (`current_file_size`, `max_file_size`) to the `quorum_queues` list. Coordination is selected with `metrics => all` and so already exposed them; the explicit quorum-queues list omitted them.

## Verified against a running broker

Confirmed on **stock RabbitMQ 4.3.4** (unpatched, Homebrew), with a quorum queue declared and 200 persistent messages published to drive WAL activity.

**Before** - the runtime holds the counters, but `/metrics` emits nothing for `quorum_queues`:

```
$ curl -s localhost:15692/metrics | grep -E 'raft_batches|raft_writes'
rabbitmq_raft_batches{module="ra_log_wal",ra_system="coordination"} 36.0
rabbitmq_raft_writes{module="ra_log_wal",ra_system="coordination"} 52.0
```

Only `ra_system="coordination"`. Meanwhile the same counters exist in the runtime for `quorum_queues`:

```erlang
%% maps:keys on the "batches" values map
[#{module => ra_log_wal, ra_system => coordination},
 #{module => ra_log_wal, ra_system => quorum_queues}]

%% quorum_queues values, present but unexposed
batches            604.0
writes             603.0
bytes_written      111666.0
current_file_size  111666.0
max_file_size      382675313.0
```

So this is a collector selection bug, not missing instrumentation.

**After** both commits, the same endpoint:

```
rabbitmq_raft_batches{module="ra_log_wal",ra_system="quorum_queues"} 604.0
rabbitmq_raft_writes{module="ra_log_wal",ra_system="quorum_queues"} 603.0
rabbitmq_raft_bytes_written{module="ra_log_wal",ra_system="quorum_queues"} 111666.0
rabbitmq_raft_wal_files{module="ra_log_wal",ra_system="quorum_queues"} 1.0
rabbitmq_raft_current_file_size{module="ra_log_wal",ra_system="quorum_queues"} 111666.0
rabbitmq_raft_max_file_size{module="ra_log_wal",ra_system="quorum_queues"} 382675313.0
```

Both `ra_system` values now appear per family, and every affected family emits exactly **one** TYPE line - checked explicitly, since duplicate TYPE lines were the regression behind #15600.

## Why the size gauges matter

The WAL rolls on size. `wal_files` only increments once a roll has happened, so on its own it reports the fsync spike after the fact rather than the rise toward it:

```promql
rabbitmq_raft_current_file_size{ra_system="quorum_queues"}
  / rabbitmq_raft_max_file_size{ra_system="quorum_queues"}
```

The WAL also batches many writes into one fsync, and the fsync rate is the quantity that maps to disk IOPS:

```promql
rate(rabbitmq_raft_batches{ra_system="quorum_queues"}[1m])
rate(rabbitmq_raft_writes{ra_system="quorum_queues"}[1m])
  / rate(rabbitmq_raft_batches{ra_system="quorum_queues"}[1m])
```

## Naming

The metric names are derived by seshat from Ra's field atoms plus the collector's existing prefix; they are not chosen here. Both new fields are plain gauges, so seshat adds no unit suffix.

This deviates from the Prometheus convention of a `_bytes` suffix on byte-valued metrics. Renaming would require either a change in Ra - which has other in-tree consumers and would break names already shipped on `/metrics/detailed` - or a name-mapping layer in the collector that does not exist today. The neighbouring `rabbitmq_raft_bytes_written` already deviates by lacking `_total`. Happy to follow maintainer preference here.

## Sequencing note

[ra#512](https://github.com/rabbitmq/ra/pull/512) ("Organize `ra_counters` by Ra system") is **open, not merged** as of this PR. If it lands it restructures the seshat group and would break every `seshat:format(ra, ...)` call, including this one. The two changes should be sequenced deliberately.

## Test coverage

`rabbit_prometheus_http_SUITE` asserts the `quorum_queues` rows for `bytes_written`, `writes`, `batches`, `wal_files`, `current_file_size` and `max_file_size`, and the duplicate-TYPE-line guard covers all of them. The CI suite has not been run locally; verification above was done by hot-loading the patched collector into a running 4.3.4 broker and diffing the endpoint.
